### PR TITLE
Fix spelling errors in comments

### DIFF
--- a/src/pcg-rngs-128.c
+++ b/src/pcg-rngs-128.c
@@ -20,8 +20,8 @@
  *
  *       http://www.pcg-random.org
  */
- 
-/* 
+
+/*
  * This code is derived from the canonical C++ PCG implementation, which
  * has many additional features and is preferable if you can use C++ in
  * your project.
@@ -123,8 +123,8 @@ extern inline void pcg_setseq_128_srandom_r(struct pcg_state_setseq_128* rng,
  *
  *     (Note that using modulo is only wise for good RNGs, poorer RNGs
  *     such as raw LCGs do better using a technique based on division.)
- *     Empricical tests show that division is preferable to modulus for
- *     reducting the range of an RNG.  It's faster, and sometimes it can
+ *     Empirical tests show that division is preferable to modulus for
+ *     reducing the range of an RNG.  It's faster, and sometimes it can
  *     even be statistically prefereable.
  */
 

--- a/src/pcg-rngs-16.c
+++ b/src/pcg-rngs-16.c
@@ -20,8 +20,8 @@
  *
  *       http://www.pcg-random.org
  */
- 
-/* 
+
+/*
  * This code is derived from the canonical C++ PCG implementation, which
  * has many additional features and is preferable if you can use C++ in
  * your project.
@@ -99,8 +99,8 @@ extern inline void pcg_setseq_16_srandom_r(struct pcg_state_setseq_16* rng,
  *
  *     (Note that using modulo is only wise for good RNGs, poorer RNGs
  *     such as raw LCGs do better using a technique based on division.)
- *     Empricical tests show that division is preferable to modulus for
- *     reducting the range of an RNG.  It's faster, and sometimes it can
+ *     Empirical tests show that division is preferable to modulus for
+ *     reducing the range of an RNG.  It's faster, and sometimes it can
  *     even be statistically prefereable.
  */
 

--- a/src/pcg-rngs-32.c
+++ b/src/pcg-rngs-32.c
@@ -20,8 +20,8 @@
  *
  *       http://www.pcg-random.org
  */
- 
-/* 
+
+/*
  * This code is derived from the canonical C++ PCG implementation, which
  * has many additional features and is preferable if you can use C++ in
  * your project.
@@ -99,8 +99,8 @@ extern inline void pcg_setseq_32_srandom_r(struct pcg_state_setseq_32* rng,
  *
  *     (Note that using modulo is only wise for good RNGs, poorer RNGs
  *     such as raw LCGs do better using a technique based on division.)
- *     Empricical tests show that division is preferable to modulus for
- *     reducting the range of an RNG.  It's faster, and sometimes it can
+ *     Empirical tests show that division is preferable to modulus for
+ *     reducing the range of an RNG.  It's faster, and sometimes it can
  *     even be statistically prefereable.
  */
 

--- a/src/pcg-rngs-64.c
+++ b/src/pcg-rngs-64.c
@@ -20,8 +20,8 @@
  *
  *       http://www.pcg-random.org
  */
- 
-/* 
+
+/*
  * This code is derived from the canonical C++ PCG implementation, which
  * has many additional features and is preferable if you can use C++ in
  * your project.
@@ -99,8 +99,8 @@ extern inline void pcg_setseq_64_srandom_r(struct pcg_state_setseq_64* rng,
  *
  *     (Note that using modulo is only wise for good RNGs, poorer RNGs
  *     such as raw LCGs do better using a technique based on division.)
- *     Empricical tests show that division is preferable to modulus for
- *     reducting the range of an RNG.  It's faster, and sometimes it can
+ *     Empirical tests show that division is preferable to modulus for
+ *     reducing the range of an RNG.  It's faster, and sometimes it can
  *     even be statistically prefereable.
  */
 

--- a/src/pcg-rngs-8.c
+++ b/src/pcg-rngs-8.c
@@ -20,8 +20,8 @@
  *
  *       http://www.pcg-random.org
  */
- 
-/* 
+
+/*
  * This code is derived from the canonical C++ PCG implementation, which
  * has many additional features and is preferable if you can use C++ in
  * your project.
@@ -97,8 +97,8 @@ extern inline void pcg_setseq_8_srandom_r(struct pcg_state_setseq_8* rng,
  *
  *     (Note that using modulo is only wise for good RNGs, poorer RNGs
  *     such as raw LCGs do better using a technique based on division.)
- *     Empricical tests show that division is preferable to modulus for
- *     reducting the range of an RNG.  It's faster, and sometimes it can
+ *     Empirical tests show that division is preferable to modulus for
+ *     reducing the range of an RNG.  It's faster, and sometimes it can
  *     even be statistically prefereable.
  */
 


### PR DESCRIPTION
_**Empricical**_ is plain wrong whereas _**reducting**_ is probably better written as _**reducing**_ .. or maybe _**redacting**_.