### PR TITLE
C comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ all:
 PREFIX = /usr/local
 
 install: all
-	install src/libpcg_random.a $PREFIX/lib
-	install -m 0644 include/pcg_variants.h $PREFIX/include
+	install src/libpcg_random.a $(PREFIX)/lib
+	install -m 0644 include/pcg_variants.h $(PREFIX)/include
 
 test:   all
 	cd test-low; $(MAKE) test
@@ -43,5 +43,3 @@ clean:
 	cd test-high; $(MAKE) clean
 	cd sample; $(MAKE) clean
 	rm -f extras/*.o
-
-	

--- a/extras/entropy.c
+++ b/extras/entropy.c
@@ -49,7 +49,7 @@
 #endif
 #endif
 
-// If HAVE_DEV_RANDOM is set, we use that value, otherwise we guess
+/* If HAVE_DEV_RANDOM is set, we use that value, otherwise we guess */
 #ifndef HAVE_DEV_RANDOM
 #define HAVE_DEV_RANDOM         IS_UNIX
 #endif
@@ -95,10 +95,10 @@ bool entropy_getbytes(void* dest, size_t size)
 
 void fallback_entropy_getbytes(void* dest, size_t size)
 {
-    // Most modern OSs use address-space randomization, meaning that we can
-    // use the address of stack variables and system library code as
-    // initializers.  It's not as good as using /dev/random, but probably
-    // better than using the current time alone.
+    /* Most modern OSs use address-space randomization, meaning that we can
+       use the address of stack variables and system library code as
+       initializers.  It's not as good as using /dev/random, but probably
+       better than using the current time alone. */
 
     static PCG_SPINLOCK_DECLARE(mutex);
     PCG_SPINLOCK_LOCK(mutex);

--- a/include/pcg_variants.h
+++ b/include/pcg_variants.h
@@ -49,8 +49,8 @@
 
 #if __GNUC_GNU_INLINE__  &&  !defined(__cplusplus)
     #error Nonstandard GNU inlining semantics. Compile with -std=c99 or better.
-    // We could instead use macros PCG_INLINE and PCG_EXTERN_INLINE
-    // but better to just reject ancient C code.
+    /* We could instead use macros PCG_INLINE and PCG_EXTERN_INLINE */
+    /* but better to just reject ancient C code. */
 #endif
 
 #if __cplusplus
@@ -98,8 +98,8 @@ inline uint32_t pcg_rotr_32(uint32_t value, unsigned int rot)
 inline uint64_t pcg_rotr_64(uint64_t value, unsigned int rot)
 {
 #if 0 && PCG_USE_INLINE_ASM && __clang__ && __x86_64__
-    // For whatever reason, clang actually *does* generate rotq by
-    // itself, so we don't need this code.
+    /* For whatever reason, clang actually *does* generate rotq by */
+    /* itself, so we don't need this code. */
     asm ("rorq   %%cl, %0" : "=r" (value) : "0" (value), "c" (rot));
     return value;
 #else
@@ -118,7 +118,7 @@ inline pcg128_t pcg_rotr_128(pcg128_t value, unsigned int rot)
  * Output functions.  These are the core of the PCG generation scheme.
  */
 
-// XSH RS
+/* XSH RS */
 
 inline uint8_t pcg_output_xsh_rs_16_8(uint16_t state)
 {
@@ -143,7 +143,7 @@ inline uint64_t pcg_output_xsh_rs_128_64(pcg128_t state)
 }
 #endif
 
-// XSH RR
+/* XSH RR */
 
 inline uint8_t pcg_output_xsh_rr_16_8(uint16_t state)
 {
@@ -167,7 +167,7 @@ inline uint64_t pcg_output_xsh_rr_128_64(pcg128_t state)
 }
 #endif
 
-// RXS M XS
+/* RXS M XS */
 
 inline uint8_t pcg_output_rxs_m_xs_8_8(uint8_t state)
 {
@@ -200,12 +200,12 @@ inline pcg128_t pcg_output_rxs_m_xs_128_128(pcg128_t state)
     pcg128_t word = ((state >> ((state >> 122u) + 6u)) ^ state)
                        * (PCG_128BIT_CONSTANT(17766728186571221404ULL,
                                               12605985483714917081ULL));
-    // 327738287884841127335028083622016905945
+    /* 327738287884841127335028083622016905945 */
     return (word >> 86u) ^ word;
 }
 #endif
 
-// XSL RR (only defined for >= 64 bits)
+/* XSL RR (only defined for >= 64 bits) */
 
 inline uint32_t pcg_output_xsl_rr_64_32(uint64_t state)
 {
@@ -221,7 +221,7 @@ inline uint64_t pcg_output_xsl_rr_128_64(pcg128_t state)
 }
 #endif
 
-// XSL RR RR (only defined for >= 64 bits)
+/* XSL RR RR (only defined for >= 64 bits) */
 
 inline uint64_t pcg_output_xsl_rr_rr_64_64(uint64_t state)
 {
@@ -2036,81 +2036,81 @@ pcg_setseq_128_xsl_rr_rr_128_boundedrand_r(struct pcg_state_setseq_128* rng,
 }
 #endif
 
-//// Typedefs
+/*// Typedefs */
 typedef struct pcg_state_setseq_64      pcg32_random_t;
 typedef struct pcg_state_64             pcg32s_random_t;
 typedef struct pcg_state_64             pcg32u_random_t;
 typedef struct pcg_state_64             pcg32f_random_t;
-//// random_r
+/*// random_r */
 #define pcg32_random_r                  pcg_setseq_64_xsh_rr_32_random_r
 #define pcg32s_random_r                 pcg_oneseq_64_xsh_rr_32_random_r
 #define pcg32u_random_r                 pcg_unique_64_xsh_rr_32_random_r
 #define pcg32f_random_r                 pcg_mcg_64_xsh_rs_32_random_r
-//// boundedrand_r
+/*// boundedrand_r */
 #define pcg32_boundedrand_r             pcg_setseq_64_xsh_rr_32_boundedrand_r
 #define pcg32s_boundedrand_r            pcg_oneseq_64_xsh_rr_32_boundedrand_r
 #define pcg32u_boundedrand_r            pcg_unique_64_xsh_rr_32_boundedrand_r
 #define pcg32f_boundedrand_r            pcg_mcg_64_xsh_rs_32_boundedrand_r
-//// srandom_r
+/*// srandom_r */
 #define pcg32_srandom_r                 pcg_setseq_64_srandom_r
 #define pcg32s_srandom_r                pcg_oneseq_64_srandom_r
 #define pcg32u_srandom_r                pcg_unique_64_srandom_r
 #define pcg32f_srandom_r                pcg_mcg_64_srandom_r
-//// advance_r
+/*// advance_r */
 #define pcg32_advance_r                 pcg_setseq_64_advance_r
 #define pcg32s_advance_r                pcg_oneseq_64_advance_r
 #define pcg32u_advance_r                pcg_unique_64_advance_r
 #define pcg32f_advance_r                pcg_mcg_64_advance_r
 
 #if PCG_HAS_128BIT_OPS
-//// Typedefs
+/*// Typedefs */
 typedef struct pcg_state_setseq_128     pcg64_random_t;
 typedef struct pcg_state_128            pcg64s_random_t;
 typedef struct pcg_state_128            pcg64u_random_t;
 typedef struct pcg_state_128            pcg64f_random_t;
-//// random_r
+/*// random_r */
 #define pcg64_random_r                  pcg_setseq_128_xsl_rr_64_random_r
 #define pcg64s_random_r                 pcg_oneseq_128_xsl_rr_64_random_r
 #define pcg64u_random_r                 pcg_unique_128_xsl_rr_64_random_r
 #define pcg64f_random_r                 pcg_mcg_128_xsl_rr_64_random_r
-//// boundedrand_r
+/*// boundedrand_r */
 #define pcg64_boundedrand_r             pcg_setseq_128_xsl_rr_64_boundedrand_r
 #define pcg64s_boundedrand_r            pcg_oneseq_128_xsl_rr_64_boundedrand_r
 #define pcg64u_boundedrand_r            pcg_unique_128_xsl_rr_64_boundedrand_r
 #define pcg64f_boundedrand_r            pcg_mcg_128_xsl_rr_64_boundedrand_r
-//// srandom_r
+/*// srandom_r */
 #define pcg64_srandom_r                 pcg_setseq_128_srandom_r
 #define pcg64s_srandom_r                pcg_oneseq_128_srandom_r
 #define pcg64u_srandom_r                pcg_unique_128_srandom_r
 #define pcg64f_srandom_r                pcg_mcg_128_srandom_r
-//// advance_r
+/*// advance_r */
 #define pcg64_advance_r                 pcg_setseq_128_advance_r
 #define pcg64s_advance_r                pcg_oneseq_128_advance_r
 #define pcg64u_advance_r                pcg_unique_128_advance_r
 #define pcg64f_advance_r                pcg_mcg_128_advance_r
 #endif
 
-//// Typedefs
+/*// Typedefs */
 typedef struct pcg_state_8              pcg8si_random_t;
 typedef struct pcg_state_16             pcg16si_random_t;
 typedef struct pcg_state_32             pcg32si_random_t;
 typedef struct pcg_state_64             pcg64si_random_t;
-//// random_r
+/*// random_r */
 #define pcg8si_random_r                 pcg_oneseq_8_rxs_m_xs_8_random_r
 #define pcg16si_random_r                pcg_oneseq_16_rxs_m_xs_16_random_r
 #define pcg32si_random_r                pcg_oneseq_32_rxs_m_xs_32_random_r
 #define pcg64si_random_r                pcg_oneseq_64_rxs_m_xs_64_random_r
-//// boundedrand_r
+/*// boundedrand_r */
 #define pcg8si_boundedrand_r            pcg_oneseq_8_rxs_m_xs_8_boundedrand_r
 #define pcg16si_boundedrand_r           pcg_oneseq_16_rxs_m_xs_16_boundedrand_r
 #define pcg32si_boundedrand_r           pcg_oneseq_32_rxs_m_xs_32_boundedrand_r
 #define pcg64si_boundedrand_r           pcg_oneseq_64_rxs_m_xs_64_boundedrand_r
-//// srandom_r
+/*// srandom_r */
 #define pcg8si_srandom_r                pcg_oneseq_8_srandom_r
 #define pcg16si_srandom_r               pcg_oneseq_16_srandom_r
 #define pcg32si_srandom_r               pcg_oneseq_32_srandom_r
 #define pcg64si_srandom_r               pcg_oneseq_64_srandom_r
-//// advance_r
+/*// advance_r */
 #define pcg8si_advance_r                pcg_oneseq_8_advance_r
 #define pcg16si_advance_r               pcg_oneseq_16_advance_r
 #define pcg32si_advance_r               pcg_oneseq_32_advance_r
@@ -2124,27 +2124,27 @@ typedef struct pcg_state_128        pcg128si_random_t;
 #define pcg128si_advance_r          pcg_oneseq_128_advance_r
 #endif
 
-//// Typedefs
+/*// Typedefs */
 typedef struct pcg_state_setseq_8       pcg8i_random_t;
 typedef struct pcg_state_setseq_16      pcg16i_random_t;
 typedef struct pcg_state_setseq_32      pcg32i_random_t;
 typedef struct pcg_state_setseq_64      pcg64i_random_t;
-//// random_r
+/*// random_r */
 #define pcg8i_random_r                  pcg_setseq_8_rxs_m_xs_8_random_r
 #define pcg16i_random_r                 pcg_setseq_16_rxs_m_xs_16_random_r
 #define pcg32i_random_r                 pcg_setseq_32_rxs_m_xs_32_random_r
 #define pcg64i_random_r                 pcg_setseq_64_rxs_m_xs_64_random_r
-//// boundedrand_r
+/*// boundedrand_r */
 #define pcg8i_boundedrand_r             pcg_setseq_8_rxs_m_xs_8_boundedrand_r
 #define pcg16i_boundedrand_r            pcg_setseq_16_rxs_m_xs_16_boundedrand_r
 #define pcg32i_boundedrand_r            pcg_setseq_32_rxs_m_xs_32_boundedrand_r
 #define pcg64i_boundedrand_r            pcg_setseq_64_rxs_m_xs_64_boundedrand_r
-//// srandom_r
+/*// srandom_r */
 #define pcg8i_srandom_r                 pcg_setseq_8_srandom_r
 #define pcg16i_srandom_r                pcg_setseq_16_srandom_r
 #define pcg32i_srandom_r                pcg_setseq_32_srandom_r
 #define pcg64i_srandom_r                pcg_setseq_64_srandom_r
-//// advance_r
+/*// advance_r */
 #define pcg8i_advance_r                 pcg_setseq_8_advance_r
 #define pcg16i_advance_r                pcg_setseq_16_advance_r
 #define pcg32i_advance_r                pcg_setseq_32_advance_r
@@ -2207,5 +2207,5 @@ extern void     pcg64_advance(pcg128_t delta);
 }
 #endif
 
-#endif // PCG_VARIANTS_H_INCLUDED
+#endif /* PCG_VARIANTS_H_INCLUDED */
 

--- a/sample/pcg32-demo.c
+++ b/sample/pcg32-demo.c
@@ -32,11 +32,11 @@
 #include <string.h>
 
 #include "pcg_variants.h"
-#include "entropy.h"                    // Wrapper around /dev/random
+#include "entropy.h"                    /* Wrapper around /dev/random */
 
 int main(int argc, char** argv)
 {
-    // Read command-line options
+    /* Read command-line options */
 
     int rounds = 5;
     bool nondeterministic_seed = false;
@@ -52,28 +52,28 @@ int main(int argc, char** argv)
         rounds = atoi(argv[0]);
     }
 
-    // In this version of the code, we'll use a local rng, rather than the
-    // global one.
+    /* In this version of the code, we'll use a local rng, rather than the */
+    /* global one. */
 
     pcg32_random_t rng;
 
-    // You should *always* seed the RNG.  The usual time to do it is the
-    // point in time when you create RNG (typically at the beginning of the
-    // program).
-    //
-    // pcg32_srandom_r takes two 64-bit constants (the initial state, and the
-    // rng sequence selector; rngs with different sequence selectors will
-    // *never* have random sequences that coincide, at all) - the code below
-    // shows three possible ways to do so.
+    /* You should *always* seed the RNG.  The usual time to do it is the
+       point in time when you create RNG (typically at the beginning of the
+       program). */
+
+    /* pcg32_srandom_r takes two 64-bit constants (the initial state, and the
+       rng sequence selector; rngs with different sequence selectors will
+       *never* have random sequences that coincide, at all) - the code below
+       shows three possible ways to do so. */
 
     if (nondeterministic_seed) {
-        // Seed with external entropy
+        /* Seed with external entropy */
 
         uint64_t seeds[2];
         entropy_getbytes((void*)seeds, sizeof(seeds));
         pcg32_srandom_r(&rng, seeds[0], seeds[1]);
     } else {
-        // Seed with a fixed constant
+        /* Seed with a fixed constant */
 
         pcg32_srandom_r(&rng, 42u, 54u);
     }

--- a/sample/pcg32-global-demo.c
+++ b/sample/pcg32-global-demo.c
@@ -32,11 +32,11 @@
 #include <string.h>
 
 #include "pcg_variants.h"
-#include "entropy.h"                    // Wrapper around /dev/random
+#include "entropy.h"                    /* Wrapper around /dev/random */
 
 int main(int argc, char** argv)
 {
-    // Read command-line options
+    /* Read command-line options */
 
     int rounds = 5;
     bool nondeterministic_seed = false;
@@ -52,26 +52,26 @@ int main(int argc, char** argv)
         rounds = atoi(argv[0]);
     }
 
-    // In this version of the code, we'll use the global rng, rather than a
-    // local one.
+    /* In this version of the code, we'll use the global rng, rather than a
+       local one. */
 
-    // You should *always* seed the RNG.  The usual time to do it is the
-    // point in time when you create RNG (typically at the beginning of the
-    // program).
-    //
-    // pcg32_srandom_r takes two 64-bit constants (the initial state, and the
-    // rng sequence selector; rngs with different sequence selectors will
-    // *never* have random sequences that coincide, at all) - the code below
-    // shows three possible ways to do so.
+    /* You should *always* seed the RNG.  The usual time to do it is the
+       point in time when you create RNG (typically at the beginning of the
+       program). */
+
+    /* pcg32_srandom_r takes two 64-bit constants (the initial state, and the
+       rng sequence selector; rngs with different sequence selectors will
+       *never* have random sequences that coincide, at all) - the code below
+       shows three possible ways to do so. */
 
     if (nondeterministic_seed) {
-        // Seed with external entropy
+        /* Seed with external entropy */
 
         uint64_t seeds[2];
         entropy_getbytes((void*)seeds, sizeof(seeds));
         pcg32_srandom(seeds[0], seeds[1]);
     } else {
-        // Seed with a fixed constant
+        /* Seed with a fixed constant */
 
         pcg32_srandom(42u, 54u);
     }

--- a/sample/pcg32x2-demo.c
+++ b/sample/pcg32x2-demo.c
@@ -32,7 +32,7 @@
 #include <string.h>
 
 #include "pcg_variants.h"
-#include "entropy.h"                    // Wrapper around /dev/random
+#include "entropy.h"                    /* Wrapper around /dev/random */
 
 /*
  * This code shows how you can cope if you're on a 32-bit platform (or a
@@ -57,7 +57,7 @@ void pcg32x2_srandom_r(pcg32x2_random_t* rng, uint64_t seed1, uint64_t seed2,
                        uint64_t seq1,  uint64_t seq2)
 {
     uint64_t mask = ~0ull >> 1;
-    // The stream for each of the two generators *must* be distinct
+    /* The stream for each of the two generators *must* be distinct */
     if ((seq1 & mask) == (seq2 & mask)) 
         seq2 = ~seq2;
     pcg32_srandom_r(rng->gen,   seed1, seq1);
@@ -93,7 +93,7 @@ uint64_t pcg32x2_boundedrand_r(pcg32x2_random_t* rng, uint64_t bound)
 
 int main(int argc, char** argv)
 {
-    // Read command-line options
+    /* Read command-line options */
 
     int rounds = 5;
     bool nondeterministic_seed = false;
@@ -109,28 +109,28 @@ int main(int argc, char** argv)
         rounds = atoi(argv[0]);
     }
 
-    // In this version of the code, we'll use a local rng, rather than the
-    // global one.
+    /* In this version of the code, we'll use a local rng, rather than the
+       global one. */
 
     pcg32x2_random_t rng;
 
-    // You should *always* seed the RNG.  The usual time to do it is the
-    // point in time when you create RNG (typically at the beginning of the
-    // program).
-    //
-    // pcg32x2_srandom_r takes four 64-bit constants (the initial state, and 
-    // the rng sequence selector; rngs with different sequence selectors will
-    // *never* have random sequences that coincide, at all) - the code below
-    // shows three possible ways to do so.
+    /* You should *always* seed the RNG.  The usual time to do it is the
+       point in time when you create RNG (typically at the beginning of the
+       program). */
+
+    /* pcg32x2_srandom_r takes four 64-bit constants (the initial state, and
+       the rng sequence selector; rngs with different sequence selectors will
+       *never* have random sequences that coincide, at all) - the code below
+       shows three possible ways to do so. */
 
     if (nondeterministic_seed) {
-        // Seed with external entropy
+        /* Seed with external entropy */
 
         uint64_t seeds[4];
         entropy_getbytes((void*)seeds, sizeof(seeds));
         pcg32x2_srandom_r(&rng, seeds[0], seeds[1], seeds[2], seeds[3]);
     } else {
-        // Seed with a fixed constant
+        /* Seed with a fixed constant */
 
         pcg32x2_srandom_r(&rng, 42u, 42u, 54u, 54u);
     }

--- a/sample/pcg64-demo.c
+++ b/sample/pcg64-demo.c
@@ -32,11 +32,11 @@
 #include <string.h>
 
 #include "pcg_variants.h"
-#include "entropy.h"                    // Wrapper around /dev/random
+#include "entropy.h"                    /* Wrapper around /dev/random */
 
 int main(int argc, char** argv)
 {
-    // Read command-line options
+    /* Read command-line options */
 
     int rounds = 5;
     bool nondeterministic_seed = false;
@@ -52,28 +52,28 @@ int main(int argc, char** argv)
         rounds = atoi(argv[0]);
     }
 
-    // In this version of the code, we'll use a local rng, rather than the
-    // global one.
+    /* In this version of the code, we'll use a local rng, rather than the
+       global one. */
 
     pcg64_random_t rng;
 
-    // You should *always* seed the RNG.  The usual time to do it is the
-    // point in time when you create RNG (typically at the beginning of the
-    // program).
-    //
-    // pcg64_srandom_r takes two 128-bit constants (the initial state, and the
-    // rng sequence selector; rngs with different sequence selectors will
-    // *never* have random sequences that coincide, at all) - the code below
-    // shows three possible ways to do so.
+    /* You should *always* seed the RNG.  The usual time to do it is the
+       point in time when you create RNG (typically at the beginning of the
+       program). */
+
+    /* pcg64_srandom_r takes two 128-bit constants (the initial state, and the
+       rng sequence selector; rngs with different sequence selectors will
+       *never* have random sequences that coincide, at all) - the code below
+       shows three possible ways to do so. */
 
     if (nondeterministic_seed) {
-        // Seed with external entropy
+        /* Seed with external entropy */
 
         pcg128_t seeds[2];
         entropy_getbytes((void*)seeds, sizeof(seeds));
         pcg64_srandom_r(&rng, seeds[0], seeds[1]);
     } else {
-        // Seed with a fixed constant
+        /* Seed with a fixed constant */
 
         pcg64_srandom_r(&rng, 42u, 54u);
     }

--- a/test-high/check-base.c
+++ b/test-high/check-base.c
@@ -27,13 +27,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "entropy.h"                    // Wrapper around /dev/random
+#include "entropy.h"                    /* Wrapper around /dev/random */
 
 XX_PREDECLS
 
 int main(int argc, char** argv)
 {
-    // Read command-line options
+    /* Read command-line options */
      
     int rounds = 5;
     bool nondeterministic_seed = false;
@@ -47,28 +47,28 @@ int main(int argc, char** argv)
          rounds = atoi(argv[0]);
     }
     
-    // In this version of the code, we'll use a local rng, rather than the
-    // global one.
+    /* In this version of the code, we'll use a local rng, rather than the
+       global one. */
     
     XX_RAND_DECL
     
-    // You should *always* seed the RNG.  The usual time to do it is the
-    // point in time when you create RNG (typically at the beginning of the
-    // program).
-    //
-    // XX_SRANDOM_R takes two YY-bit constants (the initial state, and the
-    // rng sequence selector; rngs with different sequence selectors will
-    // *never* have random sequences that coincide, at all) - the code below 
-    // shows three possible ways to do so.
+    /* You should *always* seed the RNG.  The usual time to do it is the
+       point in time when you create RNG (typically at the beginning of the
+       program). */
+
+    /* XX_SRANDOM_R takes two YY-bit constants (the initial state, and the
+       rng sequence selector; rngs with different sequence selectors will
+       *never* have random sequences that coincide, at all) - the code below
+       shows three possible ways to do so. */
 
     if (nondeterministic_seed) {
-        // Seed with external entropy
+        /* Seed with external entropy */
         
         XX_SEEDSDECL(seeds)
         entropy_getbytes((void*) seeds, sizeof(seeds)); 
         XX_SRANDOM(XX_SRANDOM_SEEDARGS(seeds));
     } else {
-        // Seed with a fixed constant
+        /* Seed with a fixed constant */
         
         XX_SRANDOM(XX_SRANDOM_SEEDCONSTS);
     }

--- a/test-low/check-base.c
+++ b/test-low/check-base.c
@@ -27,13 +27,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "entropy.h"                    // Wrapper around /dev/random
+#include "entropy.h"                    /* Wrapper around /dev/random */
 
 XX_PREDECLS
 
 int main(int argc, char** argv)
 {
-    // Read command-line options
+    /* Read command-line options */
      
     int rounds = 5;
     bool nondeterministic_seed = false;
@@ -47,28 +47,28 @@ int main(int argc, char** argv)
          rounds = atoi(argv[0]);
     }
     
-    // In this version of the code, we'll use a local rng, rather than the
-    // global one.
+    /* In this version of the code, we'll use a local rng, rather than the
+       global one. */
     
     XX_RAND_DECL
     
-    // You should *always* seed the RNG.  The usual time to do it is the
-    // point in time when you create RNG (typically at the beginning of the
-    // program).
-    //
-    // XX_SRANDOM_R takes two YY-bit constants (the initial state, and the
-    // rng sequence selector; rngs with different sequence selectors will
-    // *never* have random sequences that coincide, at all) - the code below 
-    // shows three possible ways to do so.
+    /* You should *always* seed the RNG.  The usual time to do it is the
+       point in time when you create RNG (typically at the beginning of the
+       program). */
+
+    /* XX_SRANDOM_R takes two YY-bit constants (the initial state, and the
+       rng sequence selector; rngs with different sequence selectors will
+       *never* have random sequences that coincide, at all) - the code below
+       shows three possible ways to do so. */
 
     if (nondeterministic_seed) {
-        // Seed with external entropy
+        /* Seed with external entropy */
         
         XX_SEEDSDECL(seeds)
         entropy_getbytes((void*) seeds, sizeof(seeds)); 
         XX_SRANDOM(XX_SRANDOM_SEEDARGS(seeds));
     } else {
-        // Seed with a fixed constant
+        /* Seed with a fixed constant */
         
         XX_SRANDOM(XX_SRANDOM_SEEDCONSTS);
     }


### PR DESCRIPTION
Convert C++ comments to C

Some C compilers are just strict.
Maybe we can even get away with msvc and without -std=c99 soon.
