### PR TITLE
Need parens around reference to PREFIX variable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ all:
 PREFIX = /usr/local
 
 install: all
-	install src/libpcg_random.a $PREFIX/lib
-	install -m 0644 include/pcg_variants.h $PREFIX/include
+	install src/libpcg_random.a $(PREFIX)/lib
+	install -m 0644 include/pcg_variants.h $(PREFIX)/include
 
 test:   all
 	cd test-low; $(MAKE) test


### PR DESCRIPTION
$PREFIX needs to be $(PREFIX), or "make install" will fail if the user's shell is a variant of csh.
