### PR TITLE
Use /dev/urandom instead of /dev/random

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ all:
 PREFIX = /usr/local
 
 install: all
-	install src/libpcg_random.a $PREFIX/lib
-	install -m 0644 include/pcg_variants.h $PREFIX/include
+	install src/libpcg_random.a $(PREFIX)/lib
+	install -m 0644 include/pcg_variants.h $(PREFIX)/include
 
 test:   all
 	cd test-low; $(MAKE) test

--- a/extras/entropy.c
+++ b/extras/entropy.c
@@ -61,17 +61,17 @@
 
 #if HAVE_DEV_RANDOM 
 /* entropy_getbytes(dest, size):
- *     Use /dev/random to get some external entropy for seeding purposes.
+ *     Use /dev/urandom to get some external entropy for seeding purposes.
  *
  * Note:
- *     If reading /dev/random fails (which ought to never happen), it returns
+ *     If reading /dev/urandom fails (which ought to never happen), it returns
  *     false, otherwise it returns true.  If it fails, you could instead call
  *     fallback_entropy_getbytes which always succeeds.
  */
 
 bool entropy_getbytes(void* dest, size_t size)
 {
-    int fd = open("/dev/random", O_RDONLY);
+    int fd = open("/dev/urandom", O_RDONLY);
     if (fd < 0)
         return false;
     int sz = read(fd, dest, size);

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ OBJS = pcg-advance-8.o pcg-advance-16.o pcg-advance-32.o pcg-advance-64.o \
        pcg-global-32.o pcg-global-64.o
 
 CPPFLAGS += -I../include
-CFLAGS += -O3
+CFLAGS += -O3 -fPIC
 CFLAGS   += -std=c99
 
 all: libpcg_random.a


### PR DESCRIPTION
/dev/random has blocking properties which originate from it's estimate of available system entropy running low. 

/dev/urandom is better due to its non-blocking property and also because it uses the same randomness source as /dev/random but with some extrapolation in the form of a shared CSPRNG.

See: www.2uo.de/myths-about-urandom
