### PR TITLE
Made PREFIX configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ all:
 	cd test-high; $(MAKE)
 	cd sample; $(MAKE)
 
-PREFIX = /usr/local
+PREFIX?=/usr/local
 
 install: all
-	install src/libpcg_random.a $PREFIX/lib
-	install -m 0644 include/pcg_variants.h $PREFIX/include
+	install src/libpcg_random.a $(PREFIX)/lib
+	install -m 0644 include/pcg_variants.h $(PREFIX)/include
 
 test:   all
 	cd test-low; $(MAKE) test


### PR DESCRIPTION
Here I added the option for the install location to be configurable instead of hardcoded to _/usr/local/_.

This allowed me to use **pcg** as an ExternalProject in **CMake**, where the install directory is relative to the project that depends upon **pcg**.

For example:
`PREFIX=~/out make install` should allow for it to be installed under the _out_ directory on your home (Note: I've found that the directory needs to have a _lib_ and _include subdirectories for it not save them as files.)
