### PR TITLE
wrap variables in ()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ all:
 PREFIX = /usr/local
 
 install: all
-	install src/libpcg_random.a $PREFIX/lib
-	install -m 0644 include/pcg_variants.h $PREFIX/include
+	install src/libpcg_random.a $(PREFIX)/lib
+	install -m 0644 include/pcg_variants.h $(PREFIX)/include
 
 test:   all
 	cd test-low; $(MAKE) test


### PR DESCRIPTION
This pull wraps variables in parentheses in the make file. The library will not install for me without this patch.

From https://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_6.html
> To substitute a variable's value, write a dollar sign followed by the name of the variable in parentheses or braces: either `$(foo)' or `${foo}' is a valid reference to the variable foo.
