### PR TITLE
Use standard-compliant format constant for uint64_t

### DIFF
--- a/sample/pcg32x2-demo.c
+++ b/sample/pcg32x2-demo.c
@@ -150,7 +150,7 @@ int main(int argc, char** argv)
         for (int i = 0; i < 6; ++i) {
             if (i > 0 && i % 3 == 0)
                 printf("\n\t");
-            printf(" 0x%016llx", pcg32x2_random_r(&rng));
+            printf(" 0x%016" PRIx64 "", pcg32x2_random_r(&rng));
         }
         printf("\n");
 
@@ -159,7 +159,7 @@ int main(int argc, char** argv)
         for (int i = 0; i < 6; ++i) {
             if (i > 0 && i % 3 == 0)
                 printf("\n\t");
-            printf(" 0x%016llx", pcg32x2_random_r(&rng));
+            printf(" 0x%016" PRIx64 "", pcg32x2_random_r(&rng));
         }
         printf("\n");
 

--- a/sample/pcg64-demo.c
+++ b/sample/pcg64-demo.c
@@ -92,7 +92,7 @@ int main(int argc, char** argv)
         for (int i = 0; i < 6; ++i) {
             if (i > 0 && i % 3 == 0)
                 printf("\n\t");
-            printf(" 0x%016llx", pcg64_random_r(&rng));
+            printf(" 0x%016" PRIx64 "", pcg64_random_r(&rng));
         }
         printf("\n");
 
@@ -101,7 +101,7 @@ int main(int argc, char** argv)
         for (int i = 0; i < 6; ++i) {
             if (i > 0 && i % 3 == 0)
                 printf("\n\t");
-            printf(" 0x%016llx", pcg64_random_r(&rng));
+            printf(" 0x%016" PRIx64 "", pcg64_random_r(&rng));
         }
         printf("\n");
 

--- a/test-high/check-pcg128i.c
+++ b/test-high/check-pcg128i.c
@@ -1,7 +1,7 @@
 #define XX_PREDECLS                                                            \
     void print128(pcg128_t value)                                              \
     {                                                                          \
-        printf(" 0x%016llx%016llx", (uint64_t)(value >> 64), (uint64_t)value); \
+        printf(" 0x%016" PRIx64 "%016" PRIx64 "", (uint64_t)(value >> 64), (uint64_t)value); \
     }
 
 #define XX_INFO \

--- a/test-high/check-pcg128si.c
+++ b/test-high/check-pcg128si.c
@@ -1,7 +1,7 @@
 #define XX_PREDECLS                                                            \
     void print128(pcg128_t value)                                              \
     {                                                                          \
-        printf(" 0x%016llx%016llx", (uint64_t)(value >> 64), (uint64_t)value); \
+        printf(" 0x%016" PRIx64 "%016" PRIx64 "", (uint64_t)(value >> 64), (uint64_t)value); \
     }
 
 #define XX_INFO \

--- a/test-high/check-pcg64-global.c
+++ b/test-high/check-pcg64-global.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[2];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0], seeds[1]

--- a/test-high/check-pcg64.c
+++ b/test-high/check-pcg64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                pcg64_random_t rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[2];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0], seeds[1]

--- a/test-high/check-pcg64f.c
+++ b/test-high/check-pcg64f.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                pcg64f_random_t rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-high/check-pcg64i.c
+++ b/test-high/check-pcg64i.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                pcg64i_random_t rng;
 #define XX_SEEDSDECL(seeds)         uint64_t seeds[2];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0], seeds[1]

--- a/test-high/check-pcg64s.c
+++ b/test-high/check-pcg64s.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                pcg64s_random_t rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-high/check-pcg64si.c
+++ b/test-high/check-pcg64si.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                pcg64si_random_t rng;
 #define XX_SEEDSDECL(seeds)         uint64_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-high/check-pcg64u.c
+++ b/test-high/check-pcg64u.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                pcg64u_random_t rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-mcg-128-rxs-m-64.c
+++ b/test-low/check-mcg-128-rxs-m-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-mcg-128-xsh-rr-64.c
+++ b/test-low/check-mcg-128-xsh-rr-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-mcg-128-xsh-rs-64.c
+++ b/test-low/check-mcg-128-xsh-rs-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-mcg-128-xsl-rr-64.c
+++ b/test-low/check-mcg-128-xsl-rr-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-oneseq-128-rxs-m-64.c
+++ b/test-low/check-oneseq-128-rxs-m-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-oneseq-128-rxs-m-xs-128.c
+++ b/test-low/check-oneseq-128-rxs-m-xs-128.c
@@ -1,7 +1,7 @@
 #define XX_PREDECLS                                                            \
     void print128(pcg128_t value)                                              \
     {                                                                          \
-        printf(" 0x%016llx%016llx", (uint64_t)(value >> 64), (uint64_t)value); \
+        printf(" 0x%016" PRIx64 "%016" PRIx64 "", (uint64_t)(value >> 64), (uint64_t)value); \
     }
 
 #define XX_INFO \

--- a/test-low/check-oneseq-128-xsh-rr-64.c
+++ b/test-low/check-oneseq-128-xsh-rr-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-oneseq-128-xsh-rs-64.c
+++ b/test-low/check-oneseq-128-xsh-rs-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-oneseq-128-xsl-rr-64.c
+++ b/test-low/check-oneseq-128-xsl-rr-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-oneseq-128-xsl-rr-rr-128.c
+++ b/test-low/check-oneseq-128-xsl-rr-rr-128.c
@@ -1,7 +1,7 @@
 #define XX_PREDECLS                                                            \
     void print128(pcg128_t value)                                              \
     {                                                                          \
-        printf(" 0x%016llx%016llx", (uint64_t)(value >> 64), (uint64_t)value); \
+        printf(" 0x%016" PRIx64 "%016" PRIx64 "", (uint64_t)(value >> 64), (uint64_t)value); \
     }
 
 #define XX_INFO \

--- a/test-low/check-oneseq-64-rxs-m-xs-64.c
+++ b/test-low/check-oneseq-64-rxs-m-xs-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_64 rng;
 #define XX_SEEDSDECL(seeds)         uint64_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-oneseq-64-xsl-rr-rr-64.c
+++ b/test-low/check-oneseq-64-xsl-rr-rr-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_64 rng;
 #define XX_SEEDSDECL(seeds)         uint64_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-setseq-128-rxs-m-64.c
+++ b/test-low/check-setseq-128-rxs-m-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_setseq_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[2];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0], seeds[1]

--- a/test-low/check-setseq-128-rxs-m-xs-128.c
+++ b/test-low/check-setseq-128-rxs-m-xs-128.c
@@ -1,7 +1,7 @@
 #define XX_PREDECLS                                                            \
     void print128(pcg128_t value)                                              \
     {                                                                          \
-        printf(" 0x%016llx%016llx", (uint64_t)(value >> 64), (uint64_t)value); \
+        printf(" 0x%016" PRIx64 "%016" PRIx64 "", (uint64_t)(value >> 64), (uint64_t)value); \
     }
 
 #define XX_INFO \

--- a/test-low/check-setseq-128-xsh-rr-64.c
+++ b/test-low/check-setseq-128-xsh-rr-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_setseq_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[2];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0], seeds[1]

--- a/test-low/check-setseq-128-xsh-rs-64.c
+++ b/test-low/check-setseq-128-xsh-rs-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_setseq_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[2];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0], seeds[1]

--- a/test-low/check-setseq-128-xsl-rr-64.c
+++ b/test-low/check-setseq-128-xsl-rr-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_setseq_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[2];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0], seeds[1]

--- a/test-low/check-setseq-128-xsl-rr-rr-128.c
+++ b/test-low/check-setseq-128-xsl-rr-rr-128.c
@@ -1,7 +1,7 @@
 #define XX_PREDECLS                                                            \
     void print128(pcg128_t value)                                              \
     {                                                                          \
-        printf(" 0x%016llx%016llx", (uint64_t)(value >> 64), (uint64_t)value); \
+        printf(" 0x%016" PRIx64 "%016" PRIx64 "", (uint64_t)(value >> 64), (uint64_t)value); \
     }
 
 #define XX_INFO \

--- a/test-low/check-setseq-64-rxs-m-xs-64.c
+++ b/test-low/check-setseq-64-rxs-m-xs-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_setseq_64 rng;
 #define XX_SEEDSDECL(seeds)         uint64_t seeds[2];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0], seeds[1]

--- a/test-low/check-setseq-64-xsl-rr-rr-64.c
+++ b/test-low/check-setseq-64-xsl-rr-rr-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_setseq_64 rng;
 #define XX_SEEDSDECL(seeds)         uint64_t seeds[2];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0], seeds[1]

--- a/test-low/check-unique-128-rxs-m-64.c
+++ b/test-low/check-unique-128-rxs-m-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-unique-128-rxs-m-xs-128.c
+++ b/test-low/check-unique-128-rxs-m-xs-128.c
@@ -1,7 +1,7 @@
 #define XX_PREDECLS                                                            \
     void print128(pcg128_t value)                                              \
     {                                                                          \
-        printf(" 0x%016llx%016llx", (uint64_t)(value >> 64), (uint64_t)value); \
+        printf(" 0x%016" PRIx64 "%016" PRIx64 "", (uint64_t)(value >> 64), (uint64_t)value); \
     }
 
 #define XX_INFO \

--- a/test-low/check-unique-128-xsh-rr-64.c
+++ b/test-low/check-unique-128-xsh-rr-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-unique-128-xsh-rs-64.c
+++ b/test-low/check-unique-128-xsh-rs-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-unique-128-xsl-rr-64.c
+++ b/test-low/check-unique-128-xsl-rr-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_128 rng;
 #define XX_SEEDSDECL(seeds)         pcg128_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-unique-128-xsl-rr-rr-128.c
+++ b/test-low/check-unique-128-xsl-rr-rr-128.c
@@ -1,7 +1,7 @@
 #define XX_PREDECLS                                                            \
     void print128(pcg128_t value)                                              \
     {                                                                          \
-        printf(" 0x%016llx%016llx", (uint64_t)(value >> 64), (uint64_t)value); \
+        printf(" 0x%016" PRIx64 "%016" PRIx64 "", (uint64_t)(value >> 64), (uint64_t)value); \
     }
 
 #define XX_INFO \

--- a/test-low/check-unique-64-rxs-m-xs-64.c
+++ b/test-low/check-unique-64-rxs-m-xs-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_64 rng;
 #define XX_SEEDSDECL(seeds)         uint64_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]

--- a/test-low/check-unique-64-xsl-rr-rr-64.c
+++ b/test-low/check-unique-64-xsl-rr-rr-64.c
@@ -11,7 +11,7 @@
 #define XX_NUMBITS                  "  64bit:"
 #define XX_NUMVALUES                6
 #define XX_NUMWRAP                  3
-#define XX_PRINT_RNGVAL(value)      printf(" 0x%016llx", value)
+#define XX_PRINT_RNGVAL(value)      printf(" 0x%016" PRIx64 "", value)
 #define XX_RAND_DECL                struct pcg_state_64 rng;
 #define XX_SEEDSDECL(seeds)         uint64_t seeds[1];
 #define XX_SRANDOM_SEEDARGS(seeds)  seeds[0]


### PR DESCRIPTION
This was just a search-and-replace:

for foo in $(git ls-files)
do
   sed -i 's/%016llx/%016" PRIx64 "/g' $foo
done