### PR TITLE
Fix pedantic warning

### DIFF
--- a/src/pcg-global-32.c
+++ b/src/pcg-global-32.c
@@ -49,6 +49,6 @@ void pcg32_srandom(uint64_t seed, uint64_t seq)
 
 void pcg32_advance(uint64_t delta)
 {
-    return pcg32_advance_r(&pcg32_global, delta);
+    pcg32_advance_r(&pcg32_global, delta);
 }
 


### PR DESCRIPTION
The following warning is fixed.
```
In file included from pcg-global-32.c:31:
pcg-global-32.c: In function 'pcg32_advance':
../include/pcg_variants.h:2393:41: warning: ISO C forbids 'return' with expression, in function returning void [-Wpedantic]
 2393 | #define pcg32_advance_r                 pcg_setseq_64_advance_r
pcg-global-32.c:52:12: note: in expansion of macro 'pcg32_advance_r'
   52 |     return pcg32_advance_r(&pcg32_global, delta);
      |            ^~~~~~~~~~~~~~~
pcg-global-32.c:50:6: note: declared here
   50 | void pcg32_advance(uint64_t delta)
      |      ^~~~~~~~~~~~~
```