### PR TITLE
Fix Rotation Instruction Inference

### DIFF
--- a/include/pcg_variants.h
+++ b/include/pcg_variants.h
@@ -61,14 +61,15 @@ extern "C" {
 
 inline uint8_t pcg_rotr_8(uint8_t value, unsigned int rot)
 {
-/* Unfortunately, clang is kinda pathetic when it comes to properly
- * recognizing idiomatic rotate code, so for clang we actually provide
- * assembler directives (enabled with PCG_USE_INLINE_ASM).  Boo, hiss.
+/* Older versions of this library with older versions of clang and gcc
+ * fail to infer rotation instructions. Inference is preferable to inline
+ * assembly when it works though.
  */
 #if PCG_USE_INLINE_ASM && __clang__ && (__x86_64__  || __i386__)
     asm ("rorb   %%cl, %0" : "=r" (value) : "0" (value), "c" (rot));
     return value;
 #else
+    rot &= 7;
     return (value >> rot) | (value << ((- rot) & 7));
 #endif
 }
@@ -79,6 +80,7 @@ inline uint16_t pcg_rotr_16(uint16_t value, unsigned int rot)
     asm ("rorw   %%cl, %0" : "=r" (value) : "0" (value), "c" (rot));
     return value;
 #else
+    rot &= 15;
     return (value >> rot) | (value << ((- rot) & 15));
 #endif
 }
@@ -89,6 +91,7 @@ inline uint32_t pcg_rotr_32(uint32_t value, unsigned int rot)
     asm ("rorl   %%cl, %0" : "=r" (value) : "0" (value), "c" (rot));
     return value;
 #else
+    rot &= 31;
     return (value >> rot) | (value << ((- rot) & 31));
 #endif
 }
@@ -101,6 +104,7 @@ inline uint64_t pcg_rotr_64(uint64_t value, unsigned int rot)
     asm ("rorq   %%cl, %0" : "=r" (value) : "0" (value), "c" (rot));
     return value;
 #else
+    rot &= 63;
     return (value >> rot) | (value << ((- rot) & 63));
 #endif
 }
@@ -108,6 +112,7 @@ inline uint64_t pcg_rotr_64(uint64_t value, unsigned int rot)
 #if PCG_HAS_128BIT_OPS
 inline pcg128_t pcg_rotr_128(pcg128_t value, unsigned int rot)
 {
+    rot &= 127;
     return (value >> rot) | (value << ((- rot) & 127));
 }
 #endif

--- a/include/pcg_variants.h
+++ b/include/pcg_variants.h
@@ -61,52 +61,26 @@ extern "C" {
 
 inline uint8_t pcg_rotr_8(uint8_t value, unsigned int rot)
 {
-/* Older versions of this library with older versions of clang and gcc
- * fail to infer rotation instructions. Inference is preferable to inline
- * assembly when it works though.
- */
-#if PCG_USE_INLINE_ASM && __clang__ && (__x86_64__  || __i386__)
-    asm ("rorb   %%cl, %0" : "=r" (value) : "0" (value), "c" (rot));
-    return value;
-#else
     rot &= 7;
     return (value >> rot) | (value << ((- rot) & 7));
-#endif
 }
 
 inline uint16_t pcg_rotr_16(uint16_t value, unsigned int rot)
 {
-#if PCG_USE_INLINE_ASM && __clang__ && (__x86_64__  || __i386__)
-    asm ("rorw   %%cl, %0" : "=r" (value) : "0" (value), "c" (rot));
-    return value;
-#else
     rot &= 15;
     return (value >> rot) | (value << ((- rot) & 15));
-#endif
 }
 
 inline uint32_t pcg_rotr_32(uint32_t value, unsigned int rot)
 {
-#if PCG_USE_INLINE_ASM && __clang__ && (__x86_64__  || __i386__)
-    asm ("rorl   %%cl, %0" : "=r" (value) : "0" (value), "c" (rot));
-    return value;
-#else
     rot &= 31;
     return (value >> rot) | (value << ((- rot) & 31));
-#endif
 }
 
 inline uint64_t pcg_rotr_64(uint64_t value, unsigned int rot)
 {
-#if 0 && PCG_USE_INLINE_ASM && __clang__ && __x86_64__
-    /* For whatever reason, clang actually *does* generate rotq by
-       itself, so we don't need this code. */
-    asm ("rorq   %%cl, %0" : "=r" (value) : "0" (value), "c" (rot));
-    return value;
-#else
     rot &= 63;
     return (value >> rot) | (value << ((- rot) & 63));
-#endif
 }
 
 #if PCG_HAS_128BIT_OPS

--- a/include/pcg_variants.h
+++ b/include/pcg_variants.h
@@ -61,26 +61,52 @@ extern "C" {
 
 inline uint8_t pcg_rotr_8(uint8_t value, unsigned int rot)
 {
+/* Older versions of this library with older versions of clang and gcc
+ * fail to infer rotation instructions. Inference is preferable to inline
+ * assembly when it works though.
+ */
+#if PCG_USE_INLINE_ASM && __clang__ && (__x86_64__  || __i386__)
+    asm ("rorb   %%cl, %0" : "=r" (value) : "0" (value), "c" (rot));
+    return value;
+#else
     rot &= 7;
     return (value >> rot) | (value << ((- rot) & 7));
+#endif
 }
 
 inline uint16_t pcg_rotr_16(uint16_t value, unsigned int rot)
 {
+#if PCG_USE_INLINE_ASM && __clang__ && (__x86_64__  || __i386__)
+    asm ("rorw   %%cl, %0" : "=r" (value) : "0" (value), "c" (rot));
+    return value;
+#else
     rot &= 15;
     return (value >> rot) | (value << ((- rot) & 15));
+#endif
 }
 
 inline uint32_t pcg_rotr_32(uint32_t value, unsigned int rot)
 {
+#if PCG_USE_INLINE_ASM && __clang__ && (__x86_64__  || __i386__)
+    asm ("rorl   %%cl, %0" : "=r" (value) : "0" (value), "c" (rot));
+    return value;
+#else
     rot &= 31;
     return (value >> rot) | (value << ((- rot) & 31));
+#endif
 }
 
 inline uint64_t pcg_rotr_64(uint64_t value, unsigned int rot)
 {
+#if 0 && PCG_USE_INLINE_ASM && __clang__ && __x86_64__
+    /* For whatever reason, clang actually *does* generate rotq by
+       itself, so we don't need this code. */
+    asm ("rorq   %%cl, %0" : "=r" (value) : "0" (value), "c" (rot));
+    return value;
+#else
     rot &= 63;
     return (value >> rot) | (value << ((- rot) & 63));
+#endif
 }
 
 #if PCG_HAS_128BIT_OPS


### PR DESCRIPTION
Hello,

This is a copy of https://github.com/imneme/pcg-cpp/pull/87 for your convenience to keep the C port of this library up to date, which is the version I am interested in.

In brief, it removes the need for the inline asm by adding a mask which exorcises some wacky C/C++ nasal demons and allows gcc and clang to infer a rot instruction.

Thanks,
Richard